### PR TITLE
Include a user-agent header with requests to LoremPixel

### DIFF
--- a/Section 5/menu.api.zip/src/main/java/com/drinkbird/restaurant/menu/api/MenuDatabase.java
+++ b/Section 5/menu.api.zip/src/main/java/com/drinkbird/restaurant/menu/api/MenuDatabase.java
@@ -51,6 +51,7 @@ public class MenuDatabase {
             // a different random image on every call
             logger.info("Getting random image url for: {}", categoryUrl);
             URLConnection connection = categoryUrl.openConnection();
+            connection.addRequestProperty("User-Agent", "Chrome"); //LoremPixel will now deny requests without an agent
             connection.connect();
             InputStream inputStream = connection.getInputStream();
             URL randomImageUrl = connection.getURL();


### PR DESCRIPTION
LoremPixel will now deny requests that have no user agent header set. For that reason we can include a dummy value.